### PR TITLE
Add packages required for some plots

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -17,6 +17,8 @@ dependencies:
   - surface-dynamics>=0.4.7
   - jupytext
   - ruamel.yaml
+  - three.js
+  - tachyon
   - pip
   - pip:
     - flipper

--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+python -c 'import cppyy'


### PR DESCRIPTION
This fixes the tachyon renders but this does not fix three.js due to:
```
The resource from “https://cocalc.com/nbextensions/threejs/build/three.min.js” was blocked due to MIME type (“text/html”) mismatch (X-Content-Type-Options: nosniff).
```

I vaguely remember having seen some trac ticket about this so I guess this one is unrelated.